### PR TITLE
fixed readme to show right way to grab versions from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ This module retrieves some basic [ACS](https://github.com/byu-oit/aws-acs) infor
 ## Usage
 ```hcl
 module "acs" {
-  source = "github.com/byu-oit/terraform-aws-acs-info"
-  ref = "v1.0.2"
+  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.2"
   env = "dev"
 }
 

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -3,8 +3,7 @@ provider "aws" {
 }
 
 module "acs" {
-  source = "github.com/byu-oit/terraform-aws-acs-info"
-  ref = "v1.0.2"
+  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.2"
   env = "dev"
 }
 


### PR DESCRIPTION
From slack conversation we need to use the "ref" attribute instead of "version" attribute when using modules from github. Correct?