### PR TITLE
output github token

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module retrieves some basic [ACS](https://github.com/byu-oit/aws-acs) infor
 ## Usage
 ```hcl
 module "acs" {
-  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.2"
+  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.3"
   env = "dev"
 }
 
@@ -41,5 +41,7 @@ output "permissions_boundary" {
 | data_subnets | List of data subnet [objects](https://www.terraform.io/docs/providers/aws/r/subnet.html#attributes-reference) in the specified VPC |
 | route53_zone | The Route53 zone [object](https://www.terraform.io/docs/providers/aws/r/route53_zone.html#attributes-reference) |
 | certificate | The default zone's ACM certificate [object](https://www.terraform.io/docs/providers/aws/d/acm_certificate.html#attributes-reference) |
+| github_token | The token to use in CI/CD pipelines to fetch source code from GitHub |
 
 **Note about returning objects**: Because objects are returned (as opposed to just values), autocomplete may not work. Just add on the key to the end out the output accessor. Even though autocomplete won't work, those values will still be correctly returned.
+

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "acs" {
-  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.2"
+  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.3"
   env = "dev"
 }
 
@@ -30,6 +30,11 @@ output "route53_zone_name" {
 output "cert_id" {
   value = module.acs.certificate.id
 }
+
 output "cert_arn" {
   value = module.acs.certificate.arn
+}
+
+output "github_token" {
+  value = module.acs.github_token
 }

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,11 @@ data "aws_ssm_parameter" "zone_id" {
   name = "/acs/dns/zone-id"
 }
 
+// CodePipeline parameters
+data "aws_ssm_parameter" "github_token" {
+  name = "/acs/git/token"
+}
+
 // IAM info
 data "aws_iam_role" "power_user" {
   name = "PowerUser"

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,11 @@
 
 data "aws_region" "current" {}
 
+data "aws_iam_account_alias" "current" {}
+
 locals {
-  vpc_name = "${var.vpc_vpn_to_campus ? "vpn-" : ""}oit-${data.aws_region.current.name == "us-west-2" ? "oregon-": "virginia-"}${var.env}"
+  vpc_name         = "${var.vpc_vpn_to_campus ? "vpn-" : ""}oit-${data.aws_region.current.name == "us-west-2" ? "oregon-" : "virginia-"}${var.env}"
+  has_github_token = length(regexall("^byu-oit-", data.aws_iam_account_alias.current.account_alias)) > 0
 }
 
 // IAM parameters
@@ -40,7 +43,8 @@ data "aws_ssm_parameter" "zone_id" {
 
 // CodePipeline parameters
 data "aws_ssm_parameter" "github_token" {
-  name = "/acs/git/token"
+  count = local.has_github_token ? 1 : 0
+  name  = "/acs/git/token"
 }
 
 // IAM info
@@ -63,7 +67,7 @@ data "aws_iam_policy" "user_permission_boundary" {
 // VPC info
 data "aws_vpc" "vpc" {
   tags = {
-    Name: local.vpc_name
+    Name : local.vpc_name
   }
 }
 

--- a/output.tf
+++ b/output.tf
@@ -45,5 +45,5 @@ output "certificate" {
 
 // CodePipeline outputs
 output "github_token" {
-	value = data.aws_ssm_parameter.github_token.value
+	value = local.has_github_token ? data.aws_ssm_parameter.github_token[0].value : null
 }

--- a/output.tf
+++ b/output.tf
@@ -42,3 +42,8 @@ output "route53_zone" {
 output "certificate" {
   value = data.aws_acm_certificate.cert
 }
+
+// CodePipeline outputs
+output "github_token" {
+	value = data.aws_ssm_parameter.github_token.value
+}


### PR DESCRIPTION
ACS now stores the GitHub token in SSM Parameter Store. This outputs that token, so that it can be used in CodePipelines.

I presumed this would be release v1.0.3, and updated the docs/example to reflect that.