### PR TITLE
Add security group and db subnet group outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 *.iml
 *.tfstate
+*.tfstate.backup
 .terraform
 examples/*.tfstate
 examples/.terraform

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module retrieves some basic [ACS](https://github.com/byu-oit/aws-acs) infor
 
 ```hcl
 module "acs" {
-  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.2"
+  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.1.0"
   env = "dev"
 }
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
+![Latest GitHub Release](https://img.shields.io/github/v/release/byu-oit/terraform-aws-acs-info?sort=semver)
+
 # Terraform AWS ACS Info
+
 This module retrieves some basic [ACS](https://github.com/byu-oit/aws-acs) information and exposes them via outputs. 
 
 **Note:** This module does not create nor update any resources.
 
 ## Usage
+
 ```hcl
 module "acs" {
   source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.2"
@@ -20,12 +24,14 @@ output "permissions_boundary" {
 ```
 
 ## Input
+
 | Name | Description | Default Value |
 | --- | --- | --- |
 | env | Environment of the AWS Account (e.g. dev, prd)|  |
 | vpc_vpn_to_campus | Retrieve VPC info for the VPC that has VPN access to campus | false |
 
 ## Output
+
 | Name | Description |
 | --- | --- |
 | power_user_role | The IAM PowerUser Role [object](https://www.terraform.io/docs/providers/aws/d/iam_role.html#attributes-reference) |
@@ -41,5 +47,8 @@ output "permissions_boundary" {
 | data_subnets | List of data subnet [objects](https://www.terraform.io/docs/providers/aws/r/subnet.html#attributes-reference) in the specified VPC |
 | route53_zone | The Route53 zone [object](https://www.terraform.io/docs/providers/aws/r/route53_zone.html#attributes-reference) |
 | certificate | The default zone's ACM certificate [object](https://www.terraform.io/docs/providers/aws/d/acm_certificate.html#attributes-reference) |
+| db_subnet_group_name | The database subnet group name for RDS in the specified VPC [object](https://www.terraform.io/docs/providers/aws/d/security_group.html) |
+| ssh_rdp_security_group | The security group to enable SSH/RDP access to resources in the specified VPC [object](https://www.terraform.io/docs/providers/aws/d/security_group.html) |
+| rds_security_group | The security group for RDS clusters and instances in the specified VPC |
 
 **Note about returning objects**: Because objects are returned (as opposed to just values), autocomplete may not work. Just add on the key to the end out the output accessor. Even though autocomplete won't work, those values will still be correctly returned.

--- a/main.tf
+++ b/main.tf
@@ -90,3 +90,26 @@ data "aws_acm_certificate" "cert" {
   // TODO the trim function would have been preferred, but is not available with terraform 0.12.16, fix will be available in 0.12.17
   domain = replace(data.aws_route53_zone.zone.name, "/\\.$/", "")
 }
+
+// Security Group info
+data "aws_security_group" "ssh_rdp" {
+  filter {
+    name = "vpc-id"
+    values = [data.aws_vpc.vpc.id]
+  }
+  filter {
+    name = "group-name"
+    values = ["*ssh*"]
+  }
+}
+
+data "aws_security_group" "rds" {
+  filter {
+    name = "vpc-id"
+    values = [data.aws_vpc.vpc.id]
+  }
+  filter {
+    name = "group-name"
+    values = ["*rds*"]
+  }
+}

--- a/output.tf
+++ b/output.tf
@@ -42,3 +42,18 @@ output "route53_zone" {
 output "certificate" {
   value = data.aws_acm_certificate.cert
 }
+
+// RDS Outputs
+output "db_subnet_group_name" {
+  // Terraform doens't have a data accessor for this, so we have to concatenate these strings
+  value = "${local.vpc_name}-db-subnet-group"
+}
+
+// Security Group Outputs
+output "ssh_rdp_security_group" {
+  value = data.aws_security_group.ssh_rdp
+}
+
+output "rds_security_group" {
+  value = data.aws_security_group.rds
+}


### PR DESCRIPTION
This output the SSH/RDP and RDS security groups and database subnet groups information for the specified VPC. I noticed myself needing this information when creating an RDS cluster with Terraform.

I recommend we merge this and https://github.com/byu-oit/terraform-aws-acs-info/pull/9 before releasing 1.1.0.