### PR TITLE
update version in example

### DIFF
--- a/examples/example.tf
+++ b/examples/example.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "acs" {
-  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.3"
+  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.5"
   env = "dev"
 }
 


### PR DESCRIPTION
I realized our example version number has lagged behind our releases.

Using this as an opportunity to try updating an existing tag.