### PR TITLE
Single acs parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module retrieves some basic [ACS](https://github.com/byu-oit/aws-acs) infor
 
 ```hcl
 module "acs" {
-  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.5
+  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.1.0
 }
 
 output "vpc_id" {

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "acs" {
-  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.5"
+  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.1.0"
   env = "dev"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ locals {
   public_b_subnet_id           = lookup(local.acs_info, "/acs/vpc/${local.vpc_name}-public-b", null)
   zone_id                      = lookup(local.acs_info, "/acs/dns/zone-id", null)
   oracle_security_group_id     = lookup(local.acs_info, "/acs/vpc/${data.aws_region.current.name}/${var.env}-xinetd-sg-id", null)
+  github_token                 = lookup(local.acs_info, "/acs/git/token", null)
 }
 
 // IAM info

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,20 @@ data "aws_ssm_parameter" "acs_parameters" {
 }
 
 locals {
-  vpc_name                  = "${var.vpc_vpn_to_campus ? "vpn-" : ""}oit-${data.aws_region.current.name == "us-west-2" ? "oregon-" : "virginia-"}${var.env}"
-  acs_info                  = jsondecode(data.aws_ssm_parameter.acs_parameters.value)
-  acs_keys                  = keys(local.acs_info)
-  has_oracle_security_group = contains(local.acs_keys, "/acs/vpc/${data.aws_region.current.name}/${var.env}-xinetd-sg-id")
+  vpc_name = "${var.vpc_vpn_to_campus ? "vpn-" : ""}oit-${data.aws_region.current.name == "us-west-2" ? "oregon-" : "virginia-"}${var.env}"
+
+  acs_info = jsondecode(data.aws_ssm_parameter.acs_parameters.value)
+
+  role_permission_boundary_arn = lookup(local.acs_info, "/acs/iam/iamRolePermissionBoundary", null)
+  user_permission_boundary_arn = lookup(local.acs_info, "/acs/iam/iamUserPermissionBoundary", null)
+  private_a_subnet_id          = lookup(local.acs_info, "/acs/vpc/${local.vpc_name}-private-a", null)
+  private_b_subnet_id          = lookup(local.acs_info, "/acs/vpc/${local.vpc_name}-private-b", null)
+  data_a_subnet_id             = lookup(local.acs_info, "/acs/vpc/${local.vpc_name}-data-a", null)
+  data_b_subnet_id             = lookup(local.acs_info, "/acs/vpc/${local.vpc_name}-data-b", null)
+  public_a_subnet_id           = lookup(local.acs_info, "/acs/vpc/${local.vpc_name}-public-a", null)
+  public_b_subnet_id           = lookup(local.acs_info, "/acs/vpc/${local.vpc_name}-public-b", null)
+  zone_id                      = lookup(local.acs_info, "/acs/dns/zone-id", null)
+  oracle_security_group_id     = lookup(local.acs_info, "/acs/vpc/${data.aws_region.current.name}/${var.env}-xinetd-sg-id", null)
 }
 
 // IAM info
@@ -25,10 +35,12 @@ data "aws_iam_role" "read_only" {
   name = "ReadOnly"
 }
 data "aws_iam_policy" "role_permission_boundary" {
-  arn = local.acs_info["/acs/iam/iamRolePermissionBoundary"]
+  count = local.role_permission_boundary_arn != null ? 1 : 0
+  arn   = local.role_permission_boundary_arn
 }
 data "aws_iam_policy" "user_permission_boundary" {
-  arn = local.acs_info["/acs/iam/iamUserPermissionBoundary"]
+  count = local.user_permission_boundary_arn != null ? 1 : 0
+  arn   = local.user_permission_boundary_arn
 }
 
 // VPC info
@@ -39,32 +51,40 @@ data "aws_vpc" "vpc" {
 }
 
 data "aws_subnet" "private_a" {
-  id = local.acs_info["/acs/vpc/${local.vpc_name}-private-a"]
+  count = local.private_a_subnet_id != null ? 1 : 0
+  id    = local.private_a_subnet_id
 }
 data "aws_subnet" "private_b" {
-  id = local.acs_info["/acs/vpc/${local.vpc_name}-private-b"]
+  count = local.private_b_subnet_id != null ? 1 : 0
+  id    = local.private_b_subnet_id
 }
 data "aws_subnet" "data_a" {
-  id = local.acs_info["/acs/vpc/${local.vpc_name}-data-a"]
+  count = local.data_a_subnet_id != null ? 1 : 0
+  id    = local.data_a_subnet_id
 }
 data "aws_subnet" "data_b" {
-  id = local.acs_info["/acs/vpc/${local.vpc_name}-data-b"]
+  count = local.data_b_subnet_id != null ? 1 : 0
+  id    = local.data_b_subnet_id
 }
 data "aws_subnet" "public_a" {
-  id = local.acs_info["/acs/vpc/${local.vpc_name}-public-a"]
+  count = local.public_a_subnet_id != null ? 1 : 0
+  id    = local.public_a_subnet_id
 }
 data "aws_subnet" "public_b" {
-  id = local.acs_info["/acs/vpc/${local.vpc_name}-public-b"]
+  count = local.public_b_subnet_id != null ? 1 : 0
+  id    = local.public_b_subnet_id
 }
 
 // DNS info
 data "aws_route53_zone" "zone" {
-  zone_id = local.acs_info["/acs/dns/zone-id"]
+  count   = local.zone_id != null ? 1 : 0
+  zone_id = local.zone_id
 }
 data "aws_acm_certificate" "cert" {
+  count = local.zone_id != null ? 1 : 0
   // route53 zone includes a "." at the end of the zone name and the certificate can only be retrieved without the "."
   // TODO the trim function would have been preferred, but is not available with terraform 0.12.16, fix will be available in 0.12.17
-  domain = replace(data.aws_route53_zone.zone.name, "/\\.$/", "")
+  domain = replace(data.aws_route53_zone.zone[0].name, "/\\.$/", "")
 }
 
 // Security Group info
@@ -91,6 +111,6 @@ data "aws_security_group" "rds" {
 }
 
 data "aws_security_group" "oracle" {
-  count = local.has_oracle_security_group ? 1 : 0
-  id    = local.acs_info["/acs/vpc/${data.aws_region.current.name}/${var.env}-xinetd-sg-id"]
+  count = local.oracle_security_group_id != null ? 1 : 0
+  id    = local.oracle_security_group_id
 }

--- a/main.tf
+++ b/main.tf
@@ -3,55 +3,15 @@ data "aws_region" "current" {}
 
 data "aws_iam_account_alias" "current" {}
 
+data "aws_ssm_parameter" "acs_parameters" {
+  name = "acsParameters"
+}
+
 locals {
   vpc_name                  = "${var.vpc_vpn_to_campus ? "vpn-" : ""}oit-${data.aws_region.current.name == "us-west-2" ? "oregon-" : "virginia-"}${var.env}"
-  has_oit_resources         = length(regexall("^byu-oit-|^ces-", data.aws_iam_account_alias.current.account_alias)) > 0
-  has_github_token          = local.has_oit_resources
-  has_oracle_security_group = local.has_oit_resources && var.vpc_vpn_to_campus && data.aws_region.current.name == "us-west-2"
-}
-
-// IAM parameters
-data "aws_ssm_parameter" "iam_role_permission_boundary" {
-  name = "/acs/iam/iamRolePermissionBoundary"
-}
-data "aws_ssm_parameter" "iam_user_permission_boundary" {
-  name = "/acs/iam/iamUserPermissionBoundary"
-}
-
-// VPC parameters
-data "aws_ssm_parameter" "subnet_private_a" {
-  name = "/acs/vpc/${local.vpc_name}-private-a"
-}
-data "aws_ssm_parameter" "subnet_private_b" {
-  name = "/acs/vpc/${local.vpc_name}-private-b"
-}
-data "aws_ssm_parameter" "subnet_data_a" {
-  name = "/acs/vpc/${local.vpc_name}-data-a"
-}
-data "aws_ssm_parameter" "subnet_data_b" {
-  name = "/acs/vpc/${local.vpc_name}-data-b"
-}
-data "aws_ssm_parameter" "subnet_public_a" {
-  name = "/acs/vpc/${local.vpc_name}-public-a"
-}
-data "aws_ssm_parameter" "subnet_public_b" {
-  name = "/acs/vpc/${local.vpc_name}-public-b"
-}
-data "aws_ssm_parameter" "oracle_security_group" {
-  count = local.has_oracle_security_group ? 1 : 0
-  name  = "/acs/vpc/${data.aws_region.current.name}/${var.env}-xinetd-sg-id"
-}
-
-
-// DNS parameters
-data "aws_ssm_parameter" "zone_id" {
-  name = "/acs/dns/zone-id"
-}
-
-// CodePipeline parameters
-data "aws_ssm_parameter" "github_token" {
-  count = local.has_github_token ? 1 : 0
-  name  = "/acs/git/token"
+  acs_info                  = jsondecode(data.aws_ssm_parameter.acs_parameters.value)
+  acs_keys                  = keys(local.acs_info)
+  has_oracle_security_group = contains(local.acs_keys, "/acs/vpc/${data.aws_region.current.name}/${var.env}-xinetd-sg-id")
 }
 
 // IAM info
@@ -65,10 +25,10 @@ data "aws_iam_role" "read_only" {
   name = "ReadOnly"
 }
 data "aws_iam_policy" "role_permission_boundary" {
-  arn = data.aws_ssm_parameter.iam_role_permission_boundary.value
+  arn = local.acs_info["/acs/iam/iamRolePermissionBoundary"]
 }
 data "aws_iam_policy" "user_permission_boundary" {
-  arn = data.aws_ssm_parameter.iam_user_permission_boundary.value
+  arn = local.acs_info["/acs/iam/iamUserPermissionBoundary"]
 }
 
 // VPC info
@@ -79,27 +39,27 @@ data "aws_vpc" "vpc" {
 }
 
 data "aws_subnet" "private_a" {
-  id = data.aws_ssm_parameter.subnet_private_a.value
+  id = local.acs_info["/acs/vpc/${local.vpc_name}-private-a"]
 }
 data "aws_subnet" "private_b" {
-  id = data.aws_ssm_parameter.subnet_private_b.value
+  id = local.acs_info["/acs/vpc/${local.vpc_name}-private-b"]
 }
 data "aws_subnet" "data_a" {
-  id = data.aws_ssm_parameter.subnet_data_a.value
+  id = local.acs_info["/acs/vpc/${local.vpc_name}-data-a"]
 }
 data "aws_subnet" "data_b" {
-  id = data.aws_ssm_parameter.subnet_data_b.value
+  id = local.acs_info["/acs/vpc/${local.vpc_name}-data-b"]
 }
 data "aws_subnet" "public_a" {
-  id = data.aws_ssm_parameter.subnet_public_a.value
+  id = local.acs_info["/acs/vpc/${local.vpc_name}-public-a"]
 }
 data "aws_subnet" "public_b" {
-  id = data.aws_ssm_parameter.subnet_public_b.value
+  id = local.acs_info["/acs/vpc/${local.vpc_name}-public-b"]
 }
 
 // DNS info
 data "aws_route53_zone" "zone" {
-  zone_id = data.aws_ssm_parameter.zone_id.value
+  zone_id = local.acs_info["/acs/dns/zone-id"]
 }
 data "aws_acm_certificate" "cert" {
   // route53 zone includes a "." at the end of the zone name and the certificate can only be retrieved without the "."
@@ -132,5 +92,5 @@ data "aws_security_group" "rds" {
 
 data "aws_security_group" "oracle" {
   count = local.has_oracle_security_group ? 1 : 0
-  id    = data.aws_ssm_parameter.oracle_security_group[0].value
+  id    = local.acs_info["/acs/vpc/${data.aws_region.current.name}/${var.env}-xinetd-sg-id"]
 }

--- a/output.tf
+++ b/output.tf
@@ -64,8 +64,5 @@ output "oracle_security_group" {
 
 // CodePipeline outputs
 output "github_token" {
-  // We just pull a simple string from acs_parameters. Because there is no data source,
-  // we don't need the protection offered by our count() pattern. In this case, a
-  // lookup() gives us the same protection and is simpler.
-  value = lookup(local.acs_info, "/acs/git/token", null)
+  value = local.github_token # there's no data source, so no need for the null check
 }

--- a/output.tf
+++ b/output.tf
@@ -6,10 +6,10 @@ output "power_builder_role" {
   value = data.aws_iam_role.power_builder
 }
 output "role_permissions_boundary" {
-  value = data.aws_iam_policy.role_permission_boundary
+  value = local.role_permission_boundary_arn != null ? data.aws_iam_policy.role_permission_boundary[0] : null
 }
 output "user_permissions_boundary" {
-  value = data.aws_iam_policy.user_permission_boundary
+  value = local.user_permission_boundary_arn != null ? data.aws_iam_policy.user_permission_boundary[0] : null
 }
 
 // VPC outputs
@@ -17,30 +17,30 @@ output "vpc" {
   value = data.aws_vpc.vpc
 }
 output "private_subnet_ids" {
-  value = [data.aws_subnet.private_a.id, data.aws_subnet.private_b.id]
+  value = local.private_a_subnet_id != null ? [data.aws_subnet.private_a[0].id, data.aws_subnet.private_b[0].id] : null
 }
 output "public_subnet_ids" {
-  value = [data.aws_subnet.public_a.id, data.aws_subnet.public_b.id]
+  value = local.public_a_subnet_id != null ? [data.aws_subnet.public_a[0].id, data.aws_subnet.public_b[0].id] : null
 }
 output "data_subnet_ids" {
-  value = [data.aws_subnet.data_a.id, data.aws_subnet.data_b.id]
+  value = local.data_a_subnet_id != null ? [data.aws_subnet.data_a[0].id, data.aws_subnet.data_b[0].id] : null
 }
 output "private_subnets" {
-  value = [data.aws_subnet.private_a, data.aws_subnet.private_b]
+  value = local.private_a_subnet_id != null ? [data.aws_subnet.private_a[0], data.aws_subnet.private_b[0]] : null
 }
 output "public_subnets" {
-  value = [data.aws_subnet.public_a, data.aws_subnet.public_b]
+  value = local.public_a_subnet_id != null ? [data.aws_subnet.public_a[0], data.aws_subnet.public_b[0]] : null
 }
 output "data_subnets" {
-  value = [data.aws_subnet.data_a, data.aws_subnet.data_b]
+  value = local.data_a_subnet_id != null ? [data.aws_subnet.data_a[0], data.aws_subnet.data_b[0]] : null
 }
 
 // DNS outputs
 output "route53_zone" {
-  value = data.aws_route53_zone.zone
+  value = local.zone_id != null ? data.aws_route53_zone.zone[0] : null
 }
 output "certificate" {
-  value = data.aws_acm_certificate.cert
+  value = local.zone_id != null ? data.aws_acm_certificate.cert[0] : null
 }
 
 // RDS Outputs
@@ -59,10 +59,13 @@ output "rds_security_group" {
 }
 
 output "oracle_security_group" {
-  value = local.has_oracle_security_group ? data.aws_security_group.oracle[0] : null
+  value = local.oracle_security_group_id != null ? data.aws_security_group.oracle[0] : null
 }
 
 // CodePipeline outputs
 output "github_token" {
+  // We just pull a simple string from acs_parameters. Because there is no data source,
+  // we don't need the protection offered by our count() pattern. In this case, a
+  // lookup() gives us the same protection and is simpler.
   value = lookup(local.acs_info, "/acs/git/token", null)
 }

--- a/output.tf
+++ b/output.tf
@@ -64,5 +64,5 @@ output "oracle_security_group" {
 
 // CodePipeline outputs
 output "github_token" {
-  value = local.has_github_token ? data.aws_ssm_parameter.github_token[0].value : null
+  value = lookup(local.acs_info, "/acs/git/token", null)
 }


### PR DESCRIPTION
Pulls all of the "keys" (ids/arns/etc.) from a single SSM Parameter. By doing this, we can make this module significantly more resilient.

Previously, if any SSM Parameter was missing, the module threw a 400 error. This meant that the module would break on people, even if they weren't using the missing data.

Now, if a key is missing, the module just won't create that output. So the module will only break on people who actually need that output.

In addition to being resilient to missing parameters (i.e. bugs in acs), it is now much easier to make this module flexible. We don't have to hard code which resources (data sources) exist in which account types (oit/ces/dept/org). We let the json in the SSM parameter tell us which resources to load/output.