### PR TITLE
Making acs-info-module work for non-oit accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module retrieves some basic [ACS](https://github.com/byu-oit/aws-acs) infor
 
 ```hcl
 module "acs" {
-  source = "github.com/byu-oit/terraform-aws-acs-info.git?ref=v1.2.1"
+  source = "github.com/byu-oit/terraform-aws-acs-info.git?ref=v1.2.2"
   env    = "dev"
 }
 ```
@@ -24,7 +24,7 @@ After defining the module you can then retrieve the information you need using t
 ### Usage for Non-OIT AWS account:
 ```hcl
 module "acs" {
-  source    = "github.com/byu-oit/terraform-aws-acs-info.git?ref=v1.2.1"
+  source    = "github.com/byu-oit/terraform-aws-acs-info.git?ref=v1.2.2"
   dept_abbr = "trn"
   env       = ""
 }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ After defining the module you can then retrieve the information you need using t
 
 ```
 
+### Usage for Non-OIT AWS account:
+```hcl
+module "acs" {
+  source    = "github.com/byu-oit/terraform-aws-acs-info.git?ref=v1.2.1"
+  dept_abbr = "trn"
+  env       = ""
+}
+```
+
 ## Requirements
 * Terraform version 0.12.16 or greater
 
@@ -28,8 +37,20 @@ After defining the module you can then retrieve the information you need using t
 
 | Name | Type | Description | Default Value |
 | --- | --- | --- | --- |
-| env | string | Environment of the AWS Account (e.g. dev, prd)|  |
+| dept_abbr| string | AWS Account department abbreviation (e.g. oit, trn) | oit |
+| env | string | Environment of the AWS Account (e.g. dev, prd)| |
 | vpc_vpn_to_campus | bool | Retrieve VPC info for the VPC that has VPN access to campus | false |
+
+**NOTE:** these input variables are combined to make the VPC name it tries to retrieve from your AWS account.
+```
+(<vpn>-)<dept_abbr>-<region_nickname>(-<env>)
+```
+So for instance to use the `byu-org-trn` account you need to set 
+* `dept_abbr` = `"trn"` (or blank to use default)
+* `env` = `""` (needs to be a blank string)
+* `vpc_vpn_to_campus` = `false` (or blank to use default)
+
+to use the vpc name = `trn-oregon` if in us-west-2 region or `trn-virginia` if in us-east-1
 
 ## Output
 

--- a/examples/non-oit-account/non-oit.tf
+++ b/examples/non-oit-account/non-oit.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "acs" {
 //  source = "../../"
-  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v1.2.1"
+  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v1.2.2"
   dept_abbr = "trn"
   env = ""
 }

--- a/examples/non-oit-account/non-oit.tf
+++ b/examples/non-oit-account/non-oit.tf
@@ -32,3 +32,7 @@ output "route53_zone_name" {
 output "github_token" {
   value = module.acs.github_token
 }
+
+output "cert" {
+  value = module.acs.certificate
+}

--- a/examples/non-oit-account/non-oit.tf
+++ b/examples/non-oit-account/non-oit.tf
@@ -3,8 +3,8 @@ provider "aws" {
 }
 
 module "acs" {
-  source = "../../"
-//  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v1.2.1"
+//  source = "../../"
+  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v1.2.1"
   dept_abbr = "trn"
   env = ""
 }

--- a/examples/non-oit-account/non-oit.tf
+++ b/examples/non-oit-account/non-oit.tf
@@ -1,0 +1,34 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "acs" {
+  source = "../../"
+//  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v1.2.1"
+  dept_abbr = "trn"
+  env = ""
+}
+
+output "vpc_id" {
+  value = module.acs.vpc.id
+}
+
+output "private_subnets" {
+  value = module.acs.private_subnet_ids
+}
+
+output "power_builder_role_arn" {
+  value = module.acs.power_builder_role.arn
+}
+
+output "permission_boundary" {
+  value = module.acs.role_permissions_boundary.arn
+}
+
+output "route53_zone_name" {
+  value = module.acs.route53_zone.name
+}
+
+output "github_token" {
+  value = module.acs.github_token
+}

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -3,7 +3,8 @@ provider "aws" {
 }
 
 module "acs" {
-  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v1.2.1"
+  source = "../../"
+//  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v1.2.1"
   env = "dev"
 }
 

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "acs" {
 //  source = "../../"
-  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v1.2.1"
+  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v1.2.2"
   env = "dev"
 }
 

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -3,8 +3,8 @@ provider "aws" {
 }
 
 module "acs" {
-  source = "../../"
-//  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v1.2.1"
+//  source = "../../"
+  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v1.2.1"
   env = "dev"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -28,8 +28,6 @@ locals {
   zone_id                      = lookup(local.acs_info, "/acs/dns/zone-id", null)
   oracle_security_group_id     = lookup(local.acs_info, "/acs/vpc/${data.aws_region.current.name}/${var.env}-xinetd-sg-id", null)
   github_token                 = lookup(local.acs_info, "/acs/git/token", null)
-
-  is_oit_account               = var.dept_abbr == "oit"
 }
 
 // IAM info
@@ -99,7 +97,7 @@ provider "aws" {
   region = "us-east-1"
 }
 data "aws_acm_certificate" "virginia" {
-  count    = local.zone_id != null && local.is_oit_account ? 1 : 0
+  count    = local.zone_id != null? 1 : 0
   provider = aws.virginia
   // route53 zone includes a "." at the end of the zone name and the certificate can only be retrieved without the "."
   // TODO the trim function would have been preferred, but is not available with terraform 0.12.16, fix will be available in 0.12.17
@@ -114,7 +112,7 @@ data "aws_security_group" "ssh_rdp" {
   }
   filter {
     name   = "group-name"
-    values = ["*ssh*"]
+    values = ["*ssh_rdp*"]
   }
 }
 
@@ -125,7 +123,7 @@ data "aws_security_group" "rds" {
   }
   filter {
     name   = "group-name"
-    values = ["*rds*"]
+    values = ["*rds_security_group*"]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ data "aws_route53_zone" "zone" {
   zone_id = local.zone_id
 }
 data "aws_acm_certificate" "cert" {
-  count = local.zone_id != null && local.is_oit_account ? 1 : 0
+  count = local.zone_id != null ? 1 : 0
   // route53 zone includes a "." at the end of the zone name and the certificate can only be retrieved without the "."
   // TODO the trim function would have been preferred, but is not available with terraform 0.12.16, fix will be available in 0.12.17
   domain = replace(data.aws_route53_zone.zone[0].name, "/\\.$/", "")

--- a/output.tf
+++ b/output.tf
@@ -43,7 +43,7 @@ output "certificate" {
   value = local.zone_id != null ? data.aws_acm_certificate.cert[0] : null
 }
 output "certificate_virginia" {
-  value = local.zone_id != null && local.is_oit_account ? data.aws_acm_certificate.virginia[0] : null
+  value = local.zone_id != null ? data.aws_acm_certificate.virginia[0] : null
 }
 
 // RDS Outputs

--- a/output.tf
+++ b/output.tf
@@ -40,7 +40,7 @@ output "route53_zone" {
   value = local.zone_id != null ? data.aws_route53_zone.zone[0] : null
 }
 output "certificate" {
-  value = local.zone_id != null && local.is_oit_account ? data.aws_acm_certificate.cert[0] : null
+  value = local.zone_id != null ? data.aws_acm_certificate.cert[0] : null
 }
 output "certificate_virginia" {
   value = local.zone_id != null && local.is_oit_account ? data.aws_acm_certificate.virginia[0] : null

--- a/output.tf
+++ b/output.tf
@@ -40,10 +40,10 @@ output "route53_zone" {
   value = local.zone_id != null ? data.aws_route53_zone.zone[0] : null
 }
 output "certificate" {
-  value = local.zone_id != null ? data.aws_acm_certificate.cert[0] : null
+  value = local.zone_id != null && local.is_oit_account ? data.aws_acm_certificate.cert[0] : null
 }
 output "certificate_virginia" {
-  value = local.zone_id != null ? data.aws_acm_certificate.virginia[0] : null
+  value = local.zone_id != null && local.is_oit_account ? data.aws_acm_certificate.virginia[0] : null
 }
 
 // RDS Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "env" {
   description = "Account environment (e.g. dev, prd)"
 }
 
+variable "dept_abbr" {
+  type = string
+  default = "oit"
+  description = "Abbreviation of the department type of account (e.g. oit, trn), defaults to oit."
+}
+
 variable "vpc_vpn_to_campus" {
   type        = bool
   default     = false


### PR DESCRIPTION
This adds a `dept_abbr` variable to allow for non-oit account to work. Also fixes an issue with trying to grab one security group by name `*rds*` because if there are more then one sg with that matched name terraform complains.